### PR TITLE
call support, new opcode and some formatters

### DIFF
--- a/lib/vm.cpp
+++ b/lib/vm.cpp
@@ -1,6 +1,7 @@
 #include "vm.h"
 
 #include <cstdlib>
+#include <iostream>
 #include <stdexcept>
 
 namespace interpreter {
@@ -489,12 +490,101 @@ uint32_t jmpf(uint8_t a, int32_t offset) {
     return (static_cast<int>(OP_JMPF) << OPCODE_SHIFT) | (a << A_SHIFT) | (offset + J_ZERO);
 }
 
+uint32_t move(uint8_t a, uint8_t b) {
+    return (static_cast<int>(OP_JMPF) << OPCODE_SHIFT) | (a << A_SHIFT) | (b << B_SHIFT) | 0;
+}
+
 uint32_t opcode(OpCode code, uint8_t reg_index) {
     return (static_cast<int>(code) << OPCODE_SHIFT) | (reg_index << A_SHIFT);
 }
 
 uint32_t opcode(OpCode code) {
     return (static_cast<int>(code) << OPCODE_SHIFT) ;
+}
+
+void print_opcode(uint32_t instruction) {
+    // Extract arguments from instruction
+    uint8_t opcode = instruction >> OPCODE_SHIFT;
+    uint8_t a = (instruction >> A_SHIFT) & 0xFF;
+    uint8_t b = (instruction >> B_SHIFT) & 0xFF;
+    uint8_t c = (instruction >> C_SHIFT) & 0xFF;
+    uint16_t bx = (instruction >> SBX_SHIFT) & 0xFFFF;
+    uint16_t sbx = bx;
+
+    // Print opcode name and arguments in one switch
+    switch(opcode) {
+        case OP_LOAD:
+            std::cout << "LOAD        R" << (int)a << " = constants[" << bx << "]";
+            break;
+        case OP_MOVE:
+            std::cout << "MOVE        R" << (int)a << " = R" << (int)b;
+            break;
+        case OP_LOADNIL:
+            std::cout << "LOADNIL     R" << (int)a << " = nil";
+            break;
+        case OP_ADD:
+            std::cout << "ADD         R" << (int)a << " = R" << (int)b << " + R" << (int)c;
+            break;
+        case OP_SUB:
+            std::cout << "SUB         R" << (int)a << " = R" << (int)b << " - R" << (int)c;
+            break;
+        case OP_MUL:
+            std::cout << "MUL         R" << (int)a << " = R" << (int)b << " * R" << (int)c;
+            break;
+        case OP_DIV:
+            std::cout << "DIV         R" << (int)a << " = R" << (int)b << " / R" << (int)c;
+            break;
+        case OP_MOD:
+            std::cout << "MOD         R" << (int)a << " = R" << (int)b << " % R" << (int)c;
+            break;
+        case OP_NEG:
+            std::cout << "NEG         R" << (int)a << " = -R" << (int)b;
+            break;
+        case OP_EQ:
+            std::cout << "EQ          R" << (int)a << " = R" << (int)b << " == R" << (int)c;
+            break;
+        case OP_LT:
+            std::cout << "LT          R" << (int)a << " = R" << (int)b << " < R" << (int)c;
+            break;
+        case OP_LE:
+            std::cout << "LE          R" << (int)a << " = R" << (int)b << " <= R" << (int)c;
+            break;
+        case OP_JMP:
+            std::cout << "JMP         ip += " << sbx;
+            break;
+        case OP_JMPT:
+            std::cout << "JMPT        if R" << (int)a << " ip += " << sbx;
+            break;
+        case OP_JMPF:
+            std::cout << "JMPF        if !R" << (int)a << " ip += " << sbx;
+            break;
+        case OP_CALL:
+            std::cout << "CALL        func[" << (int)a << "](args R" << (int)b
+                      << "..R" << (int)(b + c - 1) << ")";
+            break;
+        case OP_RETURN:
+            std::cout << "RETURN      return R" << (int)a;
+            break;
+        case OP_RETURNNIL:
+            std::cout << "RETURNNIL   return nil";
+            break;
+        case OP_NEWOBJ:
+            std::cout << "NEWOBJ      R" << (int)a << " = new obj(class[" << bx << "])";
+            break;
+        case OP_GETFIELD:
+            std::cout << "GETFIELD    R" << (int)a << " = R" << (int)b << ".field[" << (int)c << "]";
+            break;
+        case OP_SETFIELD:
+            std::cout << "SETFIELD    R" << (int)a << ".field[" << (int)b << "] = R" << (int)c;
+            break;
+        case OP_HALT:
+            std::cout << "HALT        halt";
+            break;
+        default:
+            std::cout << "UNKNOWN     unknown opcode";
+            break;
+    }
+    std::cout << std::endl;
 }
 
 void init_vm(std::istream& in) {

--- a/lib/vm.cpp
+++ b/lib/vm.cpp
@@ -4,7 +4,6 @@
 #include <stdexcept>
 
 namespace interpreter {
-
 VMData& vm_instance() {
     static VMData instance;
     return instance;
@@ -102,7 +101,7 @@ void op_load(VMData& vm, uint8_t reg, uint32_t const_idx) {
     if (const_idx >= vm.constants.size()) {
         throw std::out_of_range("Constant index out of range");
     }
-    vm.sp = std::max(static_cast<uint32_t>(reg), vm.sp);
+    vm.sp                 = std::max(static_cast<uint32_t>(reg), vm.sp);
     vm.stack[vm.fp + reg] = vm.constants[const_idx];
 }
 
@@ -147,8 +146,8 @@ void op_mod(VMData& vm, uint8_t dst, uint8_t src1, uint8_t src2) {
             throw std::runtime_error("Division by zero");
 
         Value res;
-        res.type = ValueType::Int;
-        res.as.i32 = v1.as.i32 % v2.as.i32;
+        res.type              = ValueType::Int;
+        res.as.i32            = v1.as.i32 % v2.as.i32;
         vm.stack[vm.fp + dst] = res;
     } else {
         throw std::runtime_error("Modulo requires integer operands");
@@ -160,10 +159,10 @@ void op_neg(VMData& vm, uint8_t dst, uint8_t src) {
     Value res;
 
     if (v.is_int()) {
-        res.type = ValueType::Int;
+        res.type   = ValueType::Int;
         res.as.i32 = -v.as.i32;
     } else if (v.is_float()) {
-        res.type = ValueType::Float;
+        res.type   = ValueType::Float;
         res.as.f32 = -v.as.f32;
     } else {
         throw std::runtime_error("Cannot negate non-numeric value");
@@ -176,7 +175,7 @@ void op_eq(VMData& vm, const uint8_t dst, const uint8_t src1, const uint8_t src2
     auto& [type2, data2] = vm.stack[vm.fp + src2];
 
     Value res;
-    res.type = ValueType::Int;
+    res.type   = ValueType::Int;
     res.as.i32 = 0;
 
     if (type1 == type2) {
@@ -300,16 +299,16 @@ void op_newobj(VMData& vm, uint8_t dst, uint32_t context_idx) {
         throw std::out_of_range("context index out of range");
     }
     if (vm.heap_size >= HEAP_MAX_SIZE) {
-        //TAG: GC
+        // TAG: GC
     }
 
     const ObjectContext field_count = vm.contexts[context_idx];
-    Object* obj = new Object{context_idx, std::vector<Value>(field_count)};
-    vm.heap[vm.heap_size] = obj;
+    Object* obj                     = new Object{context_idx, std::vector<Value>(field_count)};
+    vm.heap[vm.heap_size]           = obj;
 
     Value newobj;
-    newobj.type = ValueType::Object;
-    newobj.as.object_ptr = vm.heap_size;
+    newobj.type           = ValueType::Object;
+    newobj.as.object_ptr  = vm.heap_size;
     vm.stack[vm.fp + dst] = newobj;
 
     vm.heap_size++;
@@ -417,6 +416,23 @@ bool is_truthy(const Value& val) {
     if (val.is_char())
         return val.as.c != '\0';
     return true;  // Objects are always truthy
+}
+
+
+uint32_t opcode(OpCode code, uint8_t a, uint32_t bx) {
+    return (static_cast<int>(code) << OPCODE_SHIFT) | (a << A_SHIFT) | bx;
+}
+
+uint32_t opcode(OpCode code, uint8_t a, uint8_t b, uint8_t c) {
+    return (static_cast<int>(code) << OPCODE_SHIFT) | (a << A_SHIFT) | (b << B_SHIFT) | c;
+}
+
+uint32_t halt() {
+    return (static_cast<int>(OP_HALT) << OPCODE_SHIFT);
+}
+
+uint32_t jmp(int32_t offset) {
+    return (static_cast<int>(OP_JMP) << OPCODE_SHIFT) | (offset + J_ZERO);
 }
 
 void init_vm(std::istream& in) {

--- a/lib/vm.h
+++ b/lib/vm.h
@@ -85,7 +85,10 @@ enum OpCode {
     OP_JMPF,
 
     // Function call
-    // Args: a - function index, b - argument count
+    // Args:
+    // a - function index,
+    // b - index of register with first argument,
+    // c - argument count
     // Behavior:
     //   1. Pushes current ip/fp to call stack
     //   2. Sets new fp = sp
@@ -210,15 +213,31 @@ void run();
 void init_vm(std::istream& in);
 VMData& vm_instance();
 
-// Helper functions
+// Helper functions (creating opcode)
+
+// For: OP_LOAD, OP_NEWOBJ
 uint32_t opcode(OpCode code, uint8_t a, uint32_t bx);
+
+// For: OP_MOVE(!better use move() to not mistake), OP_ADD, OP_SUB, OP_MUL, OP_DIV, OP_MOD,
+//                OP_EQ, OP_LT, OP_LE, OP_GETFIELD, OP_SETFIELD
 uint32_t opcode(OpCode code, uint8_t a, uint8_t b, uint8_t c);
-uint32_t opcode(OpCode code, uint8_t a);  // RETURN, LOADNIL
-uint32_t opcode(OpCode code);             // RETURNNIL, HALT
+
+// For: OP_RETURN
+//      OP_LOADNIL
+//      OP_NEG
+uint32_t opcode(OpCode code, uint8_t a);
+
+// For: OP_RETURNNIL, OP_HALT
+uint32_t opcode(OpCode code);
+
 uint32_t halt();
 uint32_t jmp(int32_t offset);
 uint32_t jmpt(uint8_t a, int32_t offset);
 uint32_t jmpf(uint8_t a, int32_t offset);
+uint32_t move(uint8_t a, uint8_t b);
+
+// Printing opcode
+void print_opcode(uint32_t instruction);
 
 Value add_values(const Value& a, const Value& b);
 Value sub_values(const Value& a, const Value& b);

--- a/lib/vm.h
+++ b/lib/vm.h
@@ -206,12 +206,18 @@ void init_vm(std::istream& in);
 VMData& vm_instance();
 
 // Helper functions
+uint32_t opcode(OpCode code, uint8_t a, uint32_t bx);
+uint32_t opcode(OpCode code, uint8_t a, uint8_t b, uint8_t c);
+uint32_t halt();
+uint32_t jmp(int32_t offset);
+
 Value add_values(const Value& a, const Value& b);
 Value sub_values(const Value& a, const Value& b);
 Value mul_values(const Value& a, const Value& b);
 Value div_values(const Value& a, const Value& b);
 bool is_truthy(const Value& val);
 Value convert_value(const Value& val, ValueType target_type);
+
 
 // Instruction implementations
 void op_load(VMData& vm, uint8_t reg, uint32_t const_idx);

--- a/lib/vm.h
+++ b/lib/vm.h
@@ -101,6 +101,11 @@ enum OpCode {
     //   3. Stores result in caller's register 0
     OP_RETURN,
 
+    // Return nil from function
+    // Behavior:
+    // Works like return, but writes NIL to R0
+    OP_RETURNNIL,
+
     // Creates new object
     // Args: a - destination register, bx - class index
     // Behavior:
@@ -161,7 +166,7 @@ static constexpr uint32_t CODE_MAX_SIZE = 4096;
 static constexpr uint32_t STACK_SIZE    = 4096;
 static constexpr uint32_t HEAP_MAX_SIZE = 65536;
 static constexpr uint32_t FUNCTIONS_MAX = 256;
-static constexpr uint32_t CLASSES_MAX   = 256;
+static constexpr uint32_t CALL_MAX_SIZE = 2000;
 
 // Dispatch constants
 static constexpr uint32_t A_ARG        = 0xFF;
@@ -208,8 +213,12 @@ VMData& vm_instance();
 // Helper functions
 uint32_t opcode(OpCode code, uint8_t a, uint32_t bx);
 uint32_t opcode(OpCode code, uint8_t a, uint8_t b, uint8_t c);
+uint32_t opcode(OpCode code, uint8_t a);  // RETURN, LOADNIL
+uint32_t opcode(OpCode code);             // RETURNNIL, HALT
 uint32_t halt();
 uint32_t jmp(int32_t offset);
+uint32_t jmpt(uint8_t a, int32_t offset);
+uint32_t jmpf(uint8_t a, int32_t offset);
 
 Value add_values(const Value& a, const Value& b);
 Value sub_values(const Value& a, const Value& b);
@@ -217,7 +226,6 @@ Value mul_values(const Value& a, const Value& b);
 Value div_values(const Value& a, const Value& b);
 bool is_truthy(const Value& val);
 Value convert_value(const Value& val, ValueType target_type);
-
 
 // Instruction implementations
 void op_load(VMData& vm, uint8_t reg, uint32_t const_idx);
@@ -235,8 +243,9 @@ void op_le(VMData& vm, uint8_t dst, uint8_t src1, uint8_t src2);
 void op_jmp(VMData& vm, int32_t offset);
 void op_jmpt(VMData& vm, uint8_t cond, int32_t offset);
 void op_jmpf(VMData& vm, uint8_t cond, int32_t offset);
-void op_call(VMData& vm, uint8_t func_idx, uint8_t arg_count);
+void op_call(VMData& vm, uint8_t func_idx, uint8_t first_arg_ind, uint8_t num_args);
 void op_return(VMData& vm, uint8_t result_reg);
+void op_returnnil(VMData& vm);
 void op_newobj(VMData& vm, uint8_t dst, uint32_t class_idx);
 void op_getfield(VMData& vm, uint8_t dst, uint8_t obj, uint8_t field_idx);
 void op_setfield(VMData& vm, uint8_t obj, uint8_t field_idx, uint8_t src);

--- a/tests/vm_test.cpp
+++ b/tests/vm_test.cpp
@@ -2,13 +2,16 @@
 // Created by motya on 12.04.2025.
 //
 #include "../lib/vm.h"
-#include "utils.h"
-#include <unordered_map>
-#include <vector>
-#include <utility>
-#include <stdexcept>
-#include <algorithm>
+
 #include <gtest/gtest.h>
+
+#include <algorithm>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "utils.h"
 
 using namespace interpreter;
 
@@ -52,21 +55,19 @@ struct BytecodeHolder {
         return emit((op << 26) | (a << 18) | (b << 9) | c);
     }
 
-    BytecodeHolder& emit(OpCode op, uint8_t a, uint32_t bx) {
-        return emit((op << 26) | (a << 18) | (bx & 0x3FFFF));
-    }
+    BytecodeHolder& emit(OpCode op, uint8_t a, uint32_t bx) { return emit((op << 26) | (a << 18) | (bx & 0x3FFFF)); }
 };
 
-template<class T>
-void run_checked(const std::vector<Value>& constants, BytecodeHolder &h, T check) {
+template <class T>
+void run_checked(const std::vector<Value>& constants, BytecodeHolder& h, T check) {
     VMData& vm = vm_instance();
-    vm = VMData(); // Reset VM
+    vm         = VMData();  // Reset VM
 
     // Setup constants
     vm.constants = constants;
 
     // Copy bytecode
-    h.emit(OP_HALT << 26); // Ensure halt at end
+    h.emit(OP_HALT << 26);  // Ensure halt at end
     if (h.code.size() > CODE_MAX_SIZE) {
         throw std::runtime_error("Code size exceeds maximum");
     }
@@ -80,41 +81,59 @@ void run_checked(const std::vector<Value>& constants, BytecodeHolder &h, T check
     check(vm);
 }
 
-void run1(const std::vector<Value>& constants, BytecodeHolder &h,
-         const std::vector<Value>& expected_stack) {
-    run_checked(constants, h, [&](VMData &vm) {
+void run1(const std::vector<Value>& constants, BytecodeHolder& h, const std::vector<Value>& expected_stack) {
+    run_checked(constants, h, [&](VMData& vm) {
         ASSERT_TRUE(vm.sp == expected_stack.size());
         for (size_t i = 0; i < expected_stack.size(); ++i) {
             ASSERT_TRUE(vm.stack[i].type == expected_stack[i].type);
-            switch(expected_stack[i].type) {
-                case ValueType::Int:
-                    ASSERT_TRUE(vm.stack[i].as.i32 == expected_stack[i].as.i32);
-                    break;
-                case ValueType::Float:
-                    ASSERT_TRUE(vm.stack[i].as.f32 == expected_stack[i].as.f32);
-                    break;
-                case ValueType::Char:
-                    ASSERT_TRUE(vm.stack[i].as.c == expected_stack[i].as.c);
-                    break;
-                case ValueType::Object:
-                    ASSERT_TRUE(vm.stack[i].as.object_ptr == expected_stack[i].as.object_ptr);
-                    break;
-                case ValueType::Nil:
-                    break;
+            switch (expected_stack[i].type) {
+            case ValueType::Int:
+                ASSERT_TRUE(vm.stack[i].as.i32 == expected_stack[i].as.i32);
+                break;
+            case ValueType::Float:
+                ASSERT_TRUE(vm.stack[i].as.f32 == expected_stack[i].as.f32);
+                break;
+            case ValueType::Char:
+                ASSERT_TRUE(vm.stack[i].as.c == expected_stack[i].as.c);
+                break;
+            case ValueType::Object:
+                ASSERT_TRUE(vm.stack[i].as.object_ptr == expected_stack[i].as.object_ptr);
+                break;
+            case ValueType::Nil:
+                break;
             }
         }
     });
 }
 
 // Value creation helpers
-Value int_val(int32_t v) { Value val; val.type = ValueType::Int; val.as.i32 = v; return val; }
-Value float_val(float v) { Value val; val.type = ValueType::Float; val.as.f32 = v; return val; }
-Value char_val(char v) { Value val; val.type = ValueType::Char; val.as.c = v; return val; }
-Value nil_val() { Value val; val.type = ValueType::Nil; return val; }
+Value int_val(int32_t v) {
+    Value val;
+    val.type   = ValueType::Int;
+    val.as.i32 = v;
+    return val;
+}
+Value float_val(float v) {
+    Value val;
+    val.type   = ValueType::Float;
+    val.as.f32 = v;
+    return val;
+}
+Value char_val(char v) {
+    Value val;
+    val.type = ValueType::Char;
+    val.as.c = v;
+    return val;
+}
+Value nil_val() {
+    Value val;
+    val.type = ValueType::Nil;
+    return val;
+}
 
 VMData& initVM() {
     VMData& vm = vm_instance();
-    vm = VMData();
+    vm         = VMData();
 
     vm.ip = 0;  // Start at first instruction
     vm.fp = 0;  // Frame pointer at base
@@ -123,6 +142,23 @@ VMData& initVM() {
     return vm;
 }
 
+TEST(OpcodeCreationTest, OpcodeTest) {
+    VMData& vm = initVM();
+
+    vm.constants = {int_val(10), int_val(20), int_val(30)};
+
+    vm.code[0] = opcode(OP_LOAD, 1, 0);     // R1 = C0
+    vm.code[1] = opcode(OP_LOAD, 2, 1);     // R2 = C1
+    vm.code[2] = opcode(OP_MOVE, 1, 2, 0);  // R1 = R2
+    vm.code[3] = jmp(1);                         // ip += 1
+    vm.code[3] = opcode(OP_LOAD, 1, 3);     // R1 = C3 skip
+    vm.code[3] = halt();                              //end
+
+    run();
+
+    ASSERT_EQ(vm.stack[vm.fp + 1].as.i32, 20);
+    ASSERT_EQ(vm.stack[vm.fp + 1].type, ValueType::Int);
+}
 TEST(VmLoadTest, BasicOperation) {
     VMData& vm = initVM();
 
@@ -158,9 +194,9 @@ TEST(VmArithmeticTest, AdditionOperation) {
 
     vm.constants = {int_val(10), int_val(20)};
 
-    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = 10
-    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;  // R2 = 20
-    vm.code[2] = (OP_ADD << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | 2; // R3 = R1 + R2
+    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;                  // R1 = 10
+    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;                  // R2 = 20
+    vm.code[2] = (OP_ADD << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | 2;  // R3 = R1 + R2
     vm.code[3] = (OP_HALT << OPCODE_SHIFT);
 
     run();
@@ -185,9 +221,9 @@ TEST(VmArithmeticTest, SubtractionOperation) {
 
     vm.constants = {int_val(30), int_val(10)};
 
-    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = 30
-    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;  // R2 = 10
-    vm.code[2] = (OP_SUB << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT); // R3 = R1 - R2
+    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;                               // R1 = 30
+    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;                               // R2 = 10
+    vm.code[2] = (OP_SUB << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT);  // R3 = R1 - R2
     vm.code[3] = (OP_HALT << OPCODE_SHIFT);
 
     run();
@@ -201,9 +237,9 @@ TEST(VmArithmeticTest, MultiplicationOperation) {
 
     vm.constants = {int_val(5), int_val(6)};
 
-    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = 5
-    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;  // R2 = 6
-    vm.code[2] = (OP_MUL << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT); // R3 = R1 * R2
+    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;                               // R1 = 5
+    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;                               // R2 = 6
+    vm.code[2] = (OP_MUL << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT);  // R3 = R1 * R2
     vm.code[3] = (OP_HALT << OPCODE_SHIFT);
 
     run();
@@ -217,9 +253,9 @@ TEST(VmArithmeticTest, DivisionOperation) {
 
     vm.constants = {int_val(20), int_val(5)};
 
-    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = 20
-    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;  // R2 = 5
-    vm.code[2] = (OP_DIV << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT); // R3 = R1 / R2
+    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;                               // R1 = 20
+    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;                               // R2 = 5
+    vm.code[2] = (OP_DIV << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT);  // R3 = R1 / R2
     vm.code[3] = (OP_HALT << OPCODE_SHIFT);
 
     run();
@@ -233,9 +269,9 @@ TEST(VmArithmeticTest, ModuloOperation) {
 
     vm.constants = {int_val(10), int_val(3)};
 
-    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = 10
-    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;  // R2 = 3
-    vm.code[2] = (OP_MOD << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT); // R3 = R1 % R2
+    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;                               // R1 = 10
+    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;                               // R2 = 3
+    vm.code[2] = (OP_MOD << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT);  // R3 = R1 % R2
     vm.code[3] = (OP_HALT << OPCODE_SHIFT);
 
     run();
@@ -249,8 +285,8 @@ TEST(VmArithmeticTest, NegationOperation) {
 
     vm.constants = {int_val(42)};
 
-    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = 42
-    vm.code[1] = (OP_NEG << OPCODE_SHIFT) | (2 << A_SHIFT) | (1 << B_SHIFT); // R2 = -R1
+    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;              // R1 = 42
+    vm.code[1] = (OP_NEG << OPCODE_SHIFT) | (2 << A_SHIFT) | (1 << B_SHIFT);  // R2 = -R1
     vm.code[2] = (OP_HALT << OPCODE_SHIFT);
 
     run();
@@ -264,11 +300,11 @@ TEST(VmComparisonTest, EqualityOperation) {
 
     vm.constants = {int_val(10), int_val(10), int_val(20)};
 
-    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = 10
-    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;  // R2 = 10
-    vm.code[2] = (OP_LOAD << OPCODE_SHIFT) | (3 << A_SHIFT) | 2;  // R3 = 20
-    vm.code[3] = (OP_EQ << OPCODE_SHIFT) | (4 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT); // R4 = (R1 == R2)
-    vm.code[4] = (OP_EQ << OPCODE_SHIFT) | (5 << A_SHIFT) | (1 << B_SHIFT) | (3 << C_SHIFT); // R5 = (R1 == R3)
+    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;                              // R1 = 10
+    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;                              // R2 = 10
+    vm.code[2] = (OP_LOAD << OPCODE_SHIFT) | (3 << A_SHIFT) | 2;                              // R3 = 20
+    vm.code[3] = (OP_EQ << OPCODE_SHIFT) | (4 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT);  // R4 = (R1 == R2)
+    vm.code[4] = (OP_EQ << OPCODE_SHIFT) | (5 << A_SHIFT) | (1 << B_SHIFT) | (3 << C_SHIFT);  // R5 = (R1 == R3)
     vm.code[5] = (OP_HALT << OPCODE_SHIFT);
 
     run();
@@ -282,10 +318,10 @@ TEST(VmComparisonTest, LessThanOperation) {
 
     vm.constants = {int_val(10), int_val(20)};
 
-    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = 10
-    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;  // R2 = 20
-    vm.code[2] = (OP_LT << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT); // R3 = (R1 < R2)
-    vm.code[3] = (OP_LT << OPCODE_SHIFT) | (4 << A_SHIFT) | (2 << B_SHIFT) | (1 << C_SHIFT); // R4 = (R2 < R1)
+    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;                              // R1 = 10
+    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;                              // R2 = 20
+    vm.code[2] = (OP_LT << OPCODE_SHIFT) | (3 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT);  // R3 = (R1 < R2)
+    vm.code[3] = (OP_LT << OPCODE_SHIFT) | (4 << A_SHIFT) | (2 << B_SHIFT) | (1 << C_SHIFT);  // R4 = (R2 < R1)
     vm.code[4] = (OP_HALT << OPCODE_SHIFT);
 
     run();
@@ -300,9 +336,9 @@ TEST(VmJumpTest, UnconditionalJump) {
     vm.constants = {int_val(1), int_val(2)};
 
     // This test jumps over the second LOAD instruction
-    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = 1
-    vm.code[1] = (OP_JMP << OPCODE_SHIFT) | ((1 + J_ZERO) << SBX_SHIFT);     // Jump +2
-    vm.code[2] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;  // R2 = 2 (should be skipped)
+    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;          // R1 = 1
+    vm.code[1] = (OP_JMP << OPCODE_SHIFT) | ((1 + J_ZERO) << SBX_SHIFT);  // Jump +2
+    vm.code[2] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;          // R2 = 2 (should be skipped)
     vm.code[3] = (OP_HALT << OPCODE_SHIFT);
 
     run();
@@ -318,13 +354,13 @@ TEST(VmJumpTest, ConditionalJump) {
     vm.constants = {int_val(1), int_val(0), int_val(42)};
 
     // Test both JMPT and JMPF
-    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = 1 (true)
-    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;  // R2 = 0 (false)
-    vm.code[2] = (OP_JMPT << OPCODE_SHIFT) | (1 << A_SHIFT) | ((1 + J_ZERO) << SBX_SHIFT); // if (R1) jump +2
-    vm.code[3] = (OP_HALT << OPCODE_SHIFT);  // Should be skipped
-    vm.code[4] = (OP_JMPF << OPCODE_SHIFT) | (2 << A_SHIFT) | ((1 + J_ZERO) << SBX_SHIFT); // if (!R2) jump +2
-    vm.code[5] = (OP_HALT << OPCODE_SHIFT);  // Should be skipped
-    vm.code[6] = (OP_LOAD << OPCODE_SHIFT) | (3 << A_SHIFT) | 2;  // R3 = 42
+    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;                            // R1 = 1 (true)
+    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;                            // R2 = 0 (false)
+    vm.code[2] = (OP_JMPT << OPCODE_SHIFT) | (1 << A_SHIFT) | ((1 + J_ZERO) << SBX_SHIFT);  // if (R1) jump +2
+    vm.code[3] = (OP_HALT << OPCODE_SHIFT);                                                 // Should be skipped
+    vm.code[4] = (OP_JMPF << OPCODE_SHIFT) | (2 << A_SHIFT) | ((1 + J_ZERO) << SBX_SHIFT);  // if (!R2) jump +2
+    vm.code[5] = (OP_HALT << OPCODE_SHIFT);                                                 // Should be skipped
+    vm.code[6] = (OP_LOAD << OPCODE_SHIFT) | (3 << A_SHIFT) | 2;                            // R3 = 42
     vm.code[7] = (OP_HALT << OPCODE_SHIFT);
 
     run();
@@ -336,20 +372,20 @@ TEST(VmObjectTest, BasicObjectOperations) {
     VMData& vm = initVM();
 
     // Define a simple object context with 2 fields
-    vm.contexts = {2};
+    vm.contexts  = {2};
     vm.constants = {int_val(10), int_val(20)};
 
-    vm.code[0] = (OP_NEWOBJ << OPCODE_SHIFT) | (1 << A_SHIFT) | 0; // R1 = new object (context 0)
+    vm.code[0] = (OP_NEWOBJ << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = new object (context 0)
     vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 0;    // R2 = 10 (from constants)
-    vm.code[2] = (OP_LOAD << OPCODE_SHIFT) | (3 << A_SHIFT) | 1;   // R3 = 20
+    vm.code[2] = (OP_LOAD << OPCODE_SHIFT) | (3 << A_SHIFT) | 1;    // R3 = 20
 
     // Set fields
-    vm.code[3] = (OP_SETFIELD << OPCODE_SHIFT) | (1 << A_SHIFT) | (0 << B_SHIFT) | (2 << C_SHIFT); // obj.field0 = R2
-    vm.code[4] = (OP_SETFIELD << OPCODE_SHIFT) | (1 << A_SHIFT) | (1 << B_SHIFT) | (3 << C_SHIFT); // obj.field1 = R3
+    vm.code[3] = (OP_SETFIELD << OPCODE_SHIFT) | (1 << A_SHIFT) | (0 << B_SHIFT) | (2 << C_SHIFT);  // obj.field0 = R2
+    vm.code[4] = (OP_SETFIELD << OPCODE_SHIFT) | (1 << A_SHIFT) | (1 << B_SHIFT) | (3 << C_SHIFT);  // obj.field1 = R3
 
     // Get fields back
-    vm.code[5] = (OP_GETFIELD << OPCODE_SHIFT) | (4 << A_SHIFT) | (1 << B_SHIFT) | (0 << C_SHIFT); // R4 = obj.field0
-    vm.code[6] = (OP_GETFIELD << OPCODE_SHIFT) | (5 << A_SHIFT) | (1 << B_SHIFT) | (1 << C_SHIFT); // R5 = obj.field1
+    vm.code[5] = (OP_GETFIELD << OPCODE_SHIFT) | (4 << A_SHIFT) | (1 << B_SHIFT) | (0 << C_SHIFT);  // R4 = obj.field0
+    vm.code[6] = (OP_GETFIELD << OPCODE_SHIFT) | (5 << A_SHIFT) | (1 << B_SHIFT) | (1 << C_SHIFT);  // R5 = obj.field1
 
     vm.code[7] = (OP_HALT << OPCODE_SHIFT);
 
@@ -370,21 +406,21 @@ TEST(VmFunctionTest, BasicFunctionCall) {
     // Define a simple function that adds two numbers
     Function add_func{};
     add_func.entry_point = 5;  // Points to the ADD instruction
-    add_func.arity = 2;
-    add_func.local_count = 3;   // 2 args + 1 local
+    add_func.arity       = 2;
+    add_func.local_count = 3;  // 2 args + 1 local
 
     vm.functions[0] = add_func;
 
     // Main code
     vm.constants = {int_val(10), int_val(20)};
-    vm.code[0] = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;  // R1 = 10 (arg1)
-    vm.code[1] = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;  // R2 = 20 (arg2)
-    vm.code[2] = (OP_CALL << OPCODE_SHIFT) | (0 << A_SHIFT) | (2 << B_SHIFT); // call func 0 with 2 args
-    vm.code[3] = (OP_HALT << OPCODE_SHIFT);
+    vm.code[0]   = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;               // R1 = 10 (arg1)
+    vm.code[1]   = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;               // R2 = 20 (arg2)
+    vm.code[2]   = (OP_CALL << OPCODE_SHIFT) | (0 << A_SHIFT) | (2 << B_SHIFT);  // call func 0 with 2 args
+    vm.code[3]   = (OP_HALT << OPCODE_SHIFT);
 
     // Function code
-    vm.code[5] = (OP_ADD << OPCODE_SHIFT) | (0 << A_SHIFT) | (0 << B_SHIFT) | (1 << C_SHIFT); // R0 = R0 + R1
-    vm.code[6] = (OP_RETURN << OPCODE_SHIFT) | (0 << A_SHIFT); // return R0
+    vm.code[5] = (OP_ADD << OPCODE_SHIFT) | (0 << A_SHIFT) | (0 << B_SHIFT) | (1 << C_SHIFT);  // R0 = R0 + R1
+    vm.code[6] = (OP_RETURN << OPCODE_SHIFT) | (0 << A_SHIFT);                                 // return R0
 
     run();
 

--- a/tests/vm_test.cpp
+++ b/tests/vm_test.cpp
@@ -415,15 +415,250 @@ TEST(VmFunctionTest, BasicFunctionCall) {
     vm.constants = {int_val(10), int_val(20)};
     vm.code[0]   = (OP_LOAD << OPCODE_SHIFT) | (1 << A_SHIFT) | 0;               // R1 = 10 (arg1)
     vm.code[1]   = (OP_LOAD << OPCODE_SHIFT) | (2 << A_SHIFT) | 1;               // R2 = 20 (arg2)
-    vm.code[2]   = (OP_CALL << OPCODE_SHIFT) | (0 << A_SHIFT) | (2 << B_SHIFT);  // call func 0 with 2 args
-    vm.code[3]   = (OP_HALT << OPCODE_SHIFT);
+    // call func 0 with args from R(1) to R(2)
+    vm.code[2]   = opcode(OP_CALL, 0, 1, 2);
+    // call 2 times to ensure that sp not changed
+    vm.code[3]   = opcode(OP_CALL, 0, 1, 2);
+    vm.code[4]   = (OP_HALT << OPCODE_SHIFT);
 
     // Function code
-    vm.code[5] = (OP_ADD << OPCODE_SHIFT) | (0 << A_SHIFT) | (0 << B_SHIFT) | (1 << C_SHIFT);  // R0 = R0 + R1
+    vm.code[5] = (OP_ADD << OPCODE_SHIFT) | (0 << A_SHIFT) | (1 << B_SHIFT) | (2 << C_SHIFT);  // R0 = R1 + R2
     vm.code[6] = (OP_RETURN << OPCODE_SHIFT) | (0 << A_SHIFT);                                 // return R0
 
     run();
 
+    //last valid value in R2
+    ASSERT_EQ(vm.sp, 2);
+
     // The result should be in R0 (30)
-    ASSERT_EQ(vm.stack[vm.fp].as.i32, 30);
+    ASSERT_EQ(vm.stack[0].as.i32, 30);
+}
+TEST(VmFunctionTest, StackPointerManagement) {
+    VMData& vm = initVM();
+
+    // Function that uses all its locals
+    Function func{};
+    func.entry_point = 5;
+    func.arity = 2;
+    func.local_count = 4;  // 2 args + 2 locals
+
+    vm.functions[0] = func;
+
+    // Main code
+    vm.constants = {int_val(10), int_val(20), int_val(0)}; // 0 will be used as nil
+    vm.code[0] = opcode(OP_LOAD, 1, 0);  // R1 = 10
+    vm.code[1] = opcode(OP_LOAD, 2, 1);  // R2 = 20
+    vm.code[2] = opcode(OP_CALL, 0, 1, 2); // call func(10,20)
+    vm.code[3] = opcode(OP_HALT);
+
+    // Function code - uses all locals
+    vm.code[5] = opcode(OP_LOADNIL, 3);   // R3 = nil
+    vm.code[6] = opcode(OP_LOADNIL, 4);   // R4 = nil
+    vm.code[7] = opcode(OP_RETURNNIL);    // return nil
+
+    run();
+
+    ASSERT_EQ(vm.sp, 2);
+    ASSERT_TRUE(vm.call_stack.empty());
+}
+
+TEST(VmFunctionTest, RecursiveFunction) {
+    VMData& vm = initVM();
+
+    // Recursive function to calculate sum from n to 1
+    Function sum_func{};
+    sum_func.entry_point = 5;
+    sum_func.arity = 1;
+    sum_func.local_count = 2;  // 1 arg + 1 local
+
+    vm.functions[0] = sum_func;
+
+    // Main code and constants
+    vm.constants = {int_val(1), int_val(5)}; // 0=1, 1=5
+    vm.code[0] = opcode(OP_LOAD, 1, 1);  // R1 = 5
+    vm.code[1] = opcode(OP_CALL, 0, 1, 1); // sum(5)
+    vm.code[2] = opcode(OP_HALT);
+
+    // Function code
+    // if (n <= 1) return 1
+    vm.code[5] = opcode(OP_LOAD, 2, 0);  // R2 = 1
+    vm.code[6] = opcode(OP_LE, 3, 1, 2); // R3 = (R1 <= 1)
+    vm.code[7] = jmpf(3, 3);  // if !R3 jump +3
+    vm.code[8] = opcode(OP_LOAD, 0, 0);  // R0 = 1
+    vm.code[9] = opcode(OP_RETURN, 0);   // return 1
+    // else return n + sum(n-1)
+    vm.code[10] = opcode(OP_LOAD, 2, 0); // R2 = 1
+    vm.code[11] = opcode(OP_SUB, 4, 1, 2); // R4 = n-1
+    vm.code[12] = opcode(OP_CALL, 0, 4, 1); // sum(n-1)
+    vm.code[13] = opcode(OP_ADD, 0, 1, 0); // R0 = n + sum(n-1)
+    vm.code[14] = opcode(OP_RETURN, 0);    // return R0
+
+    run();
+
+    ASSERT_EQ(vm.stack[0].as.i32, 15);
+    ASSERT_TRUE(vm.call_stack.empty());
+}
+
+TEST(VmFunctionTest, Factorial) {
+    VMData& vm = initVM();
+
+    // Factorial function
+    Function fact_func{};
+    fact_func.entry_point = 5;
+    fact_func.arity = 1;
+    fact_func.local_count = 2;  // 1 arg + 1 local
+
+    vm.functions[0] = fact_func;
+
+    // Main code and constants
+    vm.constants = {int_val(1), int_val(6)}; // 0=1, 1=6
+    vm.code[0] = opcode(OP_LOAD, 1, 1);  // R1 = 6
+    vm.code[1] = opcode(OP_CALL, 0, 1, 1); // fact(6)
+    vm.code[2] = opcode(OP_HALT);
+
+    // Function code
+    // if (n <= 1) return 1
+    vm.code[5] = opcode(OP_LOAD, 2, 0);  // R2 = 1
+    vm.code[6] = opcode(OP_LE, 3, 1, 2); // R3 = (R1 <= 1)
+    vm.code[7] = jmpf(3, 3);  // if !R3 jump +3
+    vm.code[8] = opcode(OP_LOAD, 0, 0);  // R0 = 1
+    vm.code[9] = opcode(OP_RETURN, 0);   // return 1
+    // else return n * fact(n-1)
+    vm.code[10] = opcode(OP_LOAD, 2, 0); // R2 = 1
+    vm.code[11] = opcode(OP_SUB, 4, 1, 2); // R4 = n-1
+    vm.code[12] = opcode(OP_CALL, 0, 4, 1); // fact(n-1)
+    vm.code[13] = opcode(OP_MUL, 0, 1, 0); // R0 = n * fact(n-1)
+    vm.code[14] = opcode(OP_RETURN, 0);    // return R0
+
+    run();
+
+    ASSERT_EQ(vm.stack[0].as.i32, 720);
+    ASSERT_TRUE(vm.call_stack.empty());
+}
+
+TEST(VmFunctionTest, VoidFunction) {
+    VMData& vm = initVM();
+
+    // Function that does nothing
+    Function void_func{};
+    void_func.entry_point = 5;
+    void_func.arity = 0;
+    void_func.local_count = 0;  // just R0
+
+    vm.functions[0] = void_func;
+
+    // Main code
+    vm.code[0] = opcode(OP_CALL, 0, 0, 0); // call void_func()
+    vm.code[1] = opcode(OP_HALT);
+
+    // Function code
+    vm.code[5] = opcode(OP_RETURNNIL); // return nil
+
+    run();
+
+    ASSERT_EQ(vm.stack[0].type, ValueType::Nil);
+    ASSERT_EQ(vm.sp, 0);
+    ASSERT_TRUE(vm.call_stack.empty());
+}
+
+TEST(VmFunctionTest, NoArgsFunction) {
+    VMData& vm = initVM();
+
+    // Function that returns constant value
+    Function const_func{};
+    const_func.entry_point = 5;
+    const_func.arity = 0;
+    const_func.local_count = 0;  // just R0
+
+    vm.functions[0] = const_func;
+    vm.constants = {int_val(42)};
+
+    // Main code
+    vm.code[0] = opcode(OP_CALL, 0, 0, 0); // call const_func()
+    vm.code[1] = opcode(OP_HALT);
+
+    // Function code
+    vm.code[5] = opcode(OP_LOAD, 0, 0); // R0 = 42
+    vm.code[6] = opcode(OP_RETURN, 0);   // return R0
+
+    run();
+
+    ASSERT_EQ(vm.stack[0].as.i32, 42);
+    ASSERT_EQ(vm.sp, 0);
+    ASSERT_TRUE(vm.call_stack.empty());
+}
+
+TEST(VmFunctionTest, NestedCalls) {
+    VMData& vm = initVM();
+
+    // Function A calls function B
+    Function func_a{};
+    func_a.entry_point = 5;
+    func_a.arity = 1;
+    func_a.local_count = 2;
+
+    Function func_b{};
+    func_b.entry_point = 10;
+    func_b.arity = 1;
+    func_b.local_count = 2;
+
+    vm.functions[0] = func_a;
+    vm.functions[1] = func_b;
+    vm.constants = {int_val(10)};
+
+    // Main code
+    vm.code[0] = opcode(OP_LOAD, 1, 0);  // R1 = 10
+    vm.code[1] = opcode(OP_CALL, 0, 1, 1); // call A(10)
+    vm.code[2] = opcode(OP_HALT);
+
+    // Function A code
+    vm.code[5] = opcode(OP_CALL, 1, 1, 1); // call B(arg)
+    vm.code[6] = opcode(OP_ADD, 0, 1, 0);  // R0 = arg + B(arg)
+    vm.code[7] = opcode(OP_RETURN, 0);      // return R0
+
+    // Function B code
+    vm.code[10] = opcode(OP_LOAD, 2, 0);   // R2 = 10
+    vm.code[11] = opcode(OP_ADD, 0, 1, 2);  // R0 = arg + 10
+    vm.code[12] = opcode(OP_RETURN, 0);     // return R0
+
+    run();
+
+    ASSERT_EQ(vm.stack[0].as.i32, 30);
+    ASSERT_TRUE(vm.call_stack.empty());
+}
+
+TEST(VmFunctionTest, DeepRecursion) {
+    VMData& vm = initVM();
+
+    // Recursive countdown function
+    Function countdown{};
+    countdown.entry_point = 5;
+    countdown.arity = 1;
+    countdown.local_count = 2;
+
+    vm.functions[0] = countdown;
+    vm.constants = {int_val(1), int_val(CALL_MAX_SIZE)};
+
+    // Main code - start with 100
+    vm.code[0] = opcode(OP_LOAD, 1, 1);  // R1 = MAX
+    vm.code[1] = opcode(OP_CALL, 0, 1, 1); // countdown(MAX)
+    vm.code[2] = opcode(OP_HALT);
+
+    // Function code
+    // if (n <= 1) return 1
+    vm.code[5] = opcode(OP_LOAD, 2, 0);  // R2 = 1
+    vm.code[6] = opcode(OP_LE, 3, 1, 2); // R3 = (R1 <= 1)
+    vm.code[7] = jmpf(3, 3);  // if !R3 jump +3
+    vm.code[8] = opcode(OP_LOAD, 0, 0);  // R0 = 1
+    vm.code[9] = opcode(OP_RETURN, 0);   // return 1
+    // else return countdown(n-1)
+    vm.code[10] = opcode(OP_LOAD, 2, 0); // R2 = 1
+    vm.code[11] = opcode(OP_SUB, 4, 1, 2); // R4 = n-1
+    vm.code[12] = opcode(OP_CALL, 0, 4, 1); // countdown(n-1)
+    vm.code[13] = opcode(OP_RETURN, 0);    // return result
+
+    run();
+
+    ASSERT_EQ(vm.stack[0].as.i32, 1);
+    ASSERT_TRUE(vm.call_stack.empty());
 }


### PR DESCRIPTION
helper for creating opcode
**BE AWARE:** 
opcode MOVE and some others contain ARG_A and ARG_B but NOT ARG_C
so usage must be 
`opcode(MOVE, a, b,0), `
 NOT
` opcode(MOVE, a, bx)`